### PR TITLE
fix(estree): strict typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "@typescript-eslint/typescript-estree": "^4.11.1"
   },
   "devDependencies": {
-    "typescript": "^4.1.3"
+    "typescript": "3.6.0"
   }
 }


### PR DESCRIPTION
currently installed version of TypeScript is not officially supported by typescript-estree.
SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.6.0